### PR TITLE
OstSdk change: 

### DIFF
--- a/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstBaseWorkFlow.java
+++ b/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstBaseWorkFlow.java
@@ -389,13 +389,17 @@ abstract class OstBaseWorkFlow implements OstPinAcceptInterface {
         if (null == mOstToken || TextUtils.isEmpty(mOstToken.getChainId()) ||
                 TextUtils.isEmpty(mOstToken.getBtDecimals())) {
             //Make API Call.
-            try {
-                mOstApiClient.getToken();
-                mOstToken = OstToken.getById(tokenId);
-            } catch (IOException e) {
-                Log.i(TAG, "Encountered IOException while fetching token.");
-                throw new OstError("wp_base_eot_1", ErrorCode.TOKEN_API_FAILED);
-            }
+            syncOstToken();
+        }
+    }
+
+    void syncOstToken() {
+        try {
+            mOstApiClient.getToken();
+            mOstToken = OstToken.getById(mOstUser.getTokenId());
+        } catch (IOException e) {
+            Log.i(TAG, "Encountered IOException while fetching token.");
+            throw new OstError("wp_base_eot_1", ErrorCode.TOKEN_API_FAILED);
         }
     }
 

--- a/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstBaseWorkFlow.java
+++ b/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstBaseWorkFlow.java
@@ -399,7 +399,7 @@ abstract class OstBaseWorkFlow implements OstPinAcceptInterface {
             mOstToken = OstToken.getById(mOstUser.getTokenId());
         } catch (IOException e) {
             Log.i(TAG, "Encountered IOException while fetching token.");
-            throw new OstError("wp_base_eot_1", ErrorCode.TOKEN_API_FAILED);
+            throw new OstError("wp_base_sot_1", ErrorCode.TOKEN_API_FAILED);
         }
     }
 

--- a/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
+++ b/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
@@ -120,7 +120,7 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
 
                     //Sync if needed.
                     if ( status.isSuccess() ) {
-                        sync();
+                        sync(mForceSync);
                         //Forward it.
                         return postFlowComplete(new OstContextEntity(
                                 ostUser.getCurrentDevice(),
@@ -136,10 +136,8 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
                     AsyncStatus verificationStatus = verifyDeviceRegistered();
 
                     if ( verificationStatus.isSuccess() ) {
-                        //Sync Registered Entities.
-                        ensureApiCommunication();
-                        ensureOstUser(true);
-                        ensureOstToken();
+                        //Force Sync Registered Entities.
+                        sync(true);
                         //Forward it.
                         return postFlowComplete(new OstContextEntity(
                                 mOstUser.getCurrentDevice(),
@@ -166,13 +164,11 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
     }
 
     //region - Helper methods
-    private void sync() {
+    private void sync(boolean forceSync) {
         Log.i(TAG, String.format("Syncing sdk: %b", mForceSync));
-        if (mForceSync) {
-            ensureApiCommunication();
-            ensureOstUser(true);
-            ensureDeviceManager();
-            ensureOstToken();
+        if (forceSync) {
+            syncOstUser();
+            syncOstToken();
         }
     }
 

--- a/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
+++ b/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
@@ -162,9 +162,15 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
         if (mForceSync) {
             syncOstUser();
             syncOstToken();
+            if (mOstUser.isActivated()) {
+                syncDeviceManager();
+            }
         } else {
             ensureOstUser();
             ensureOstToken();
+            if (mOstUser.isActivated()) {
+                ensureDeviceManager();
+            }
         }
     }
 
@@ -175,7 +181,7 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
             @Override
             public void run() {
                 OstWorkFlowCallback callback = getCallback();
-                if ( null != callback ) {
+                if (null != callback) {
                     callback.registerDevice(apiResponse, OstRegisterDevice.this);
                 } else {
                     //Do Nothing, let the workflow die.
@@ -214,27 +220,17 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
     }
 
     private AsyncStatus verifyDeviceRegistered() {
-        try {
-            //Just sync current device.
-            syncCurrentDevice();
+        //Just sync current device.
+        syncCurrentDevice();
 
-            //Get the currentDevice
-            OstUser ostUser = OstUser.getById(mUserId);
-            OstDevice device = ostUser.getCurrentDevice();
+        //Get the currentDevice
+        OstUser ostUser = OstUser.getById(mUserId);
+        OstDevice device = ostUser.getCurrentDevice();
 
-            if (device.canMakeApiCall()) {
-                return new AsyncStatus(true);
-            } else {
-                throw new OstError("wf_rd_vdr_1", ErrorCode.DEVICE_NOT_REGISTERED);
-            }
-        } catch (OstError error) {
-            //This could happen.
-            return postErrorInterrupt( error );
-        } catch (Exception ex) {
-            //Catch all unexpected errors.
-            OstError error = new OstError("wf_rd_vdr_1", ErrorCode.UNCAUGHT_EXCEPTION_HANDELED);
-            error.setStackTrace( ex.getStackTrace() );
-            return postErrorInterrupt( error );
+        if (device.canMakeApiCall()) {
+            return new AsyncStatus(true);
+        } else {
+            throw new OstError("wf_rd_vdr_1", ErrorCode.DEVICE_NOT_REGISTERED);
         }
     }
     //endregion

--- a/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
+++ b/ostsdk/src/main/java/com/ost/walletsdk/workflows/OstRegisterDevice.java
@@ -227,11 +227,10 @@ public class OstRegisterDevice extends OstBaseWorkFlow implements OstDeviceRegis
         OstUser ostUser = OstUser.getById(mUserId);
         OstDevice device = ostUser.getCurrentDevice();
 
-        if (device.canMakeApiCall()) {
-            return new AsyncStatus(true);
-        } else {
+        if (!device.canMakeApiCall()) {
             throw new OstError("wf_rd_vdr_1", ErrorCode.DEVICE_NOT_REGISTERED);
         }
+        return new AsyncStatus(true);
     }
     //endregion
 }


### PR DESCRIPTION
DeviceManager might not be available while doing Register workflow, therefore It should not be part of sync.
And In case of force sync, user and token entities should be synced instead of ensure.